### PR TITLE
Integrate cube navigation and wiki content

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -29,6 +29,11 @@
                 "glob": "**/*",
                 "input": "src/assets",
                 "output": "/assets"
+              },
+              {
+                "glob": "**/*",
+                "input": "src/docs",
+                "output": "/docs"
               }
             ]
             ,
@@ -98,6 +103,11 @@
                 "glob": "**/*",
                 "input": "src/assets",
                 "output": "/assets"
+              },
+              {
+                "glob": "**/*",
+                "input": "src/docs",
+                "output": "/docs"
               }
             ]
             ,

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "@tweenjs/tween.js": "^25.0.0",
         "@types/three": "^0.169.0",
         "express": "^4.18.2",
+        "marked": "^12.0.2",
         "rxjs": "~7.8.0",
         "three": "^0.169.0",
         "three-stdlib": "^2.34.0",
@@ -9434,6 +9435,18 @@
       },
       "engines": {
         "node": "^16.14.0 || >=18.0.0"
+      }
+    },
+    "node_modules/marked": {
+      "version": "12.0.2",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-12.0.2.tgz",
+      "integrity": "sha512-qXUm7e/YKFoqFPYPa3Ukg9xlI5cyAtGmyEIzMfW//m6kXwCy2Ps9DYf5ioijFKQ8qyuscrHoY04iJGctu2Kg0Q==",
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 18"
       }
     },
     "node_modules/media-typer": {

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "@tweenjs/tween.js": "^25.0.0",
     "@types/three": "^0.169.0",
     "express": "^4.18.2",
+    "marked": "^12.0.2",
     "rxjs": "~7.8.0",
     "three": "^0.169.0",
     "three-stdlib": "^2.34.0",

--- a/src/app/about/about.component.css
+++ b/src/app/about/about.component.css
@@ -1,0 +1,64 @@
+:host {
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+  color: #111827;
+}
+
+.page-header {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.eyebrow {
+  font-size: 0.75rem;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  font-weight: 600;
+}
+
+.title {
+  font-size: clamp(2rem, 4vw, 2.8rem);
+  line-height: 1.1;
+  font-weight: 700;
+}
+
+.lede {
+  font-size: 1rem;
+  max-width: 40rem;
+  line-height: 1.6;
+}
+
+.about-grid {
+  display: grid;
+  gap: 1.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(14rem, 1fr));
+}
+
+.card {
+  border: 2px solid #111827;
+  padding: 1.5rem;
+  background: #f9fafb;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  line-height: 1.6;
+}
+
+.card h2 {
+  font-size: 1.1rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.card ul {
+  list-style: square;
+  margin: 0;
+  padding-left: 1.2rem;
+}
+
+.card li {
+  margin-bottom: 0.35rem;
+}

--- a/src/app/about/about.component.html
+++ b/src/app/about/about.component.html
@@ -1,1 +1,36 @@
-<p>about works!</p>
+<section class="page-header">
+  <p class="eyebrow">About</p>
+  <h1 class="title">Mechanical Systems Strategist</h1>
+  <p class="lede">
+    I design, test, and refine immersive mechanical experiences that blend tactile engineering with
+    digital storytelling. The portfolio cube is my navigation playground, and every panel hides a
+    narrative worth exploring.
+  </p>
+</section>
+
+<section class="about-grid">
+  <article class="card">
+    <h2>Design Philosophy</h2>
+    <p>
+      I believe in modular systems that can be pulled apart, studied, and reassembled into something
+      stronger. Each interaction is prototyped physically before it becomes a digital animation, ensuring
+      that motion feels purposeful and precise.
+    </p>
+  </article>
+  <article class="card">
+    <h2>Current Focus</h2>
+    <p>
+      Crafting portfolio experiences that feel engineered rather than templated. Recent experiments
+      include kinetic layouts, physics-driven navigation, and collaborative documentation pipelines that
+      keep teams aligned.
+    </p>
+  </article>
+  <article class="card">
+    <h2>Toolbox</h2>
+    <ul>
+      <li>Advanced CAD modeling for rapid ideation</li>
+      <li>Angular + Three.js for interactive storytelling</li>
+      <li>Documentation systems that scale with iteration</li>
+    </ul>
+  </article>
+</section>

--- a/src/app/app.component.css
+++ b/src/app/app.component.css
@@ -1,0 +1,64 @@
+.three-container-wrapper {
+  position: relative;
+}
+
+.content-overlay {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(255, 255, 255, 0.85);
+  backdrop-filter: blur(6px);
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.5s ease;
+  padding: 1.5rem;
+}
+
+.content-overlay--visible {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+.content-panel {
+  width: min(48rem, 100%);
+  max-height: 100%;
+  overflow-y: auto;
+  border: 2px solid #000;
+  background-color: #fff;
+  box-shadow: 8px 8px 0 0 #000;
+  padding: 2rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.content-close {
+  align-self: flex-end;
+  border: 2px solid #000;
+  background: #fff;
+  color: #000;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  padding: 0.5rem 1rem;
+  text-transform: uppercase;
+  transition: background-color 0.3s ease, color 0.3s ease;
+}
+
+.content-close:hover,
+.content-close:focus {
+  background: #000;
+  color: #fff;
+}
+
+@media (max-width: 768px) {
+  .content-panel {
+    padding: 1.5rem;
+    box-shadow: 4px 4px 0 0 #000;
+  }
+
+  .content-close {
+    width: 100%;
+  }
+}

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -72,38 +72,19 @@
 
   <!-- 3d model rendering -->
   <div class="three-container-wrapper relative z-0 w-full h-[80vh] overflow-hidden">
-    <app-three-model></app-three-model>
-  </div>
-
-  <!-- Navigation Box (Title Block) -->
-  <div class="absolute bottom-10 right-10 bg-white border-2 border-black p-4 shadow-md" style="width: 250px;">
-      <h3 class="text-lg font-bold text-center mb-2">Navigation</h3>
-      <nav class="flex flex-col">
-        <a
-          routerLink="/about"
-          class="uppercase text-md font-semibold border-2 border-black p-2 mb-1 hover:bg-gray-200"
-        >
-          About
-        </a>
-        <a
-          routerLink="/resume"
-          class="uppercase text-md font-semibold border-2 border-black p-2 mb-1 hover:bg-gray-200"
-        >
-          Resume
-        </a>
-        <a
-          routerLink="/portfolio"
-          class="uppercase text-md font-semibold border-2 border-black p-2 mb-1 hover:bg-gray-200"
-        >
-          Portfolio
-        </a>
-        <a
-          routerLink="/wiki"
-          class="uppercase text-md font-semibold border-2 border-black p-2 hover:bg-gray-200"
-        >
-          Wiki
-        </a>
-      </nav>
+    <app-three-model
+      #threeModel
+      (sectionFocus)="handleSectionFocus($event)"
+      (sectionReveal)="handleSectionReveal()"
+    ></app-three-model>
+    <div class="content-overlay" [class.content-overlay--visible]="showContent">
+      <div class="content-panel">
+        <button class="content-close" type="button" (click)="closeContent()">
+          Return to navigation
+        </button>
+        <router-outlet></router-outlet>
+      </div>
+    </div>
   </div>
 </div>
 

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,7 +1,7 @@
-import { CommonModule } from '@angular/common'; // Import CommonModule
-import { Component } from '@angular/core';
-import { RouterOutlet } from '@angular/router';
-import { ThreeModelComponent } from './three-model/three-model.component'; // Import the component
+import { CommonModule } from '@angular/common';
+import { Component, ViewChild } from '@angular/core';
+import { Router, RouterOutlet } from '@angular/router';
+import { ThreeModelComponent, SectionEvent } from './three-model/three-model.component';
 
 @Component({
   selector: 'app-root',
@@ -12,5 +12,28 @@ import { ThreeModelComponent } from './three-model/three-model.component'; // Im
 })
 export class AppComponent {
   title = 'mechanical-portfolio';
-  todayDate = new Date();  // Initialize the current date
+  todayDate = new Date();
+  showContent = false;
+  activeSection: SectionEvent['key'] | null = null;
+
+  @ViewChild(ThreeModelComponent)
+  private threeModel?: ThreeModelComponent;
+
+  constructor(private router: Router) {}
+
+  handleSectionFocus(event: SectionEvent): void {
+    this.activeSection = event.key;
+    this.showContent = false;
+    void this.router.navigate(['/', event.key]);
+  }
+
+  handleSectionReveal(): void {
+    this.showContent = true;
+  }
+
+  closeContent(): void {
+    this.showContent = false;
+    this.activeSection = null;
+    this.threeModel?.resetSelection();
+  }
 }

--- a/src/app/app.config.ts
+++ b/src/app/app.config.ts
@@ -3,7 +3,13 @@ import { provideRouter } from '@angular/router';
 
 import { routes } from './app.routes';
 import { provideClientHydration } from '@angular/platform-browser';
+import { provideHttpClient } from '@angular/common/http';
 
 export const appConfig: ApplicationConfig = {
-  providers: [provideZoneChangeDetection({ eventCoalescing: true }), provideRouter(routes), provideClientHydration()]
+  providers: [
+    provideZoneChangeDetection({ eventCoalescing: true }),
+    provideRouter(routes),
+    provideClientHydration(),
+    provideHttpClient()
+  ]
 };

--- a/src/app/portfolio/portfolio.component.css
+++ b/src/app/portfolio/portfolio.component.css
@@ -1,0 +1,61 @@
+:host {
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+  color: #111827;
+}
+
+.page-header {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.eyebrow {
+  font-size: 0.75rem;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  font-weight: 600;
+}
+
+.title {
+  font-size: clamp(2rem, 4vw, 2.6rem);
+  line-height: 1.1;
+  font-weight: 700;
+}
+
+.lede {
+  font-size: 1rem;
+  max-width: 42rem;
+  line-height: 1.6;
+}
+
+.portfolio-grid {
+  display: grid;
+  gap: 1.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(16rem, 1fr));
+}
+
+.card {
+  border: 2px solid #111827;
+  padding: 1.5rem;
+  background: linear-gradient(135deg, #f8fafc 0%, #eef2ff 100%);
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  line-height: 1.6;
+}
+
+.card h2 {
+  font-size: 1.1rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.meta {
+  font-size: 0.85rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  margin-top: auto;
+}

--- a/src/app/portfolio/portfolio.component.html
+++ b/src/app/portfolio/portfolio.component.html
@@ -1,1 +1,35 @@
-<p>portfolio works!</p>
+<section class="page-header">
+  <p class="eyebrow">Portfolio</p>
+  <h1 class="title">Selected Builds & Experiments</h1>
+  <p class="lede">
+    A rotating collection of mechanical showcases. Each prototype leans on modular components, narrative
+    tooling, and a tactile interface that invites people to explore how the system works.
+  </p>
+</section>
+
+<section class="portfolio-grid">
+  <article class="card">
+    <h2>Adaptive Inspection Cube</h2>
+    <p>
+      The inspiration for this site&rsquo;s navigation. A physical cube with magnetic faces that reveal
+      documentation, CAD overlays, and live system telemetry when expanded.
+    </p>
+    <p class="meta">Role: Lead mechanical designer &mdash; Tools: Fusion 360, Angular, Three.js</p>
+  </article>
+  <article class="card">
+    <h2>Remote Field Kit</h2>
+    <p>
+      A ruggedized kit for technicians working in remote environments. Included self-healing wiring
+      harnesses, quick-swap actuators, and QR-driven maintenance guides synced to a central wiki.
+    </p>
+    <p class="meta">Role: Systems engineer &mdash; Tools: SolidWorks, Notion API, Vercel</p>
+  </article>
+  <article class="card">
+    <h2>Motion Lab Atlas</h2>
+    <p>
+      A data viz platform that overlays captured motion tests onto 3D rigs. Blends sensor data with
+      procedural animations so stakeholders can see the impact of each design iteration instantly.
+    </p>
+    <p class="meta">Role: Technical director &mdash; Tools: Blender, Typescript, WebGL</p>
+  </article>
+</section>

--- a/src/app/resume/resume.component.css
+++ b/src/app/resume/resume.component.css
@@ -1,0 +1,68 @@
+:host {
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+  color: #111827;
+}
+
+.page-header {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.eyebrow {
+  font-size: 0.75rem;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  font-weight: 600;
+}
+
+.title {
+  font-size: clamp(2rem, 4vw, 2.6rem);
+  line-height: 1.1;
+  font-weight: 700;
+}
+
+.lede {
+  font-size: 1rem;
+  max-width: 42rem;
+  line-height: 1.6;
+}
+
+.resume-grid {
+  display: grid;
+  gap: 1.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(15rem, 1fr));
+}
+
+.card {
+  border: 2px solid #111827;
+  padding: 1.5rem;
+  background: #ffffff;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  line-height: 1.6;
+  box-shadow: 4px 4px 0 0 #111827;
+}
+
+.card h2 {
+  font-size: 1rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.card ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.card li strong {
+  font-weight: 700;
+}

--- a/src/app/resume/resume.component.html
+++ b/src/app/resume/resume.component.html
@@ -1,1 +1,35 @@
-<p>resume works!</p>
+<section class="page-header">
+  <p class="eyebrow">Resume</p>
+  <h1 class="title">Mechanical Experience Snapshot</h1>
+  <p class="lede">
+    Twelve years of building multi-disciplinary machines, digital twins, and operational playbooks. I
+    translate prototypes into production and keep documentation breathable for the people who use it.
+  </p>
+</section>
+
+<section class="resume-grid">
+  <article class="card">
+    <h2>Core Roles</h2>
+    <ul>
+      <li><strong>Lead Mechanical Architect</strong> &mdash; Atlas Robotics (2021&ndash;Present)</li>
+      <li><strong>Systems Engineer</strong> &mdash; Vectron Dynamics (2016&ndash;2021)</li>
+      <li><strong>Prototype Specialist</strong> &mdash; Independent Studio (2012&ndash;2016)</li>
+    </ul>
+  </article>
+  <article class="card">
+    <h2>Skills at a Glance</h2>
+    <ul>
+      <li>Design for manufacturing & maintenance documentation</li>
+      <li>Simulation pipelines for kinematics and control</li>
+      <li>Stakeholder facilitation and workshop leadership</li>
+    </ul>
+  </article>
+  <article class="card">
+    <h2>Highlights</h2>
+    <p>
+      Led the redesign of an autonomous inspection rig, cutting calibration time by 42%. Built a living
+      wiki so technicians could remix procedures in the field. Crafted training modules that pair tactile
+      learning with interactive 3D walkthroughs.
+    </p>
+  </article>
+</section>

--- a/src/app/three-model/three-model.component.css
+++ b/src/app/three-model/three-model.component.css
@@ -1,5 +1,39 @@
 .three-container {
   width: 100%;
-  height: 100vh;
+  height: 100%;
+  position: relative;
   overflow: hidden;
+}
+
+.three-container canvas {
+  width: 100% !important;
+  height: 100% !important;
+  display: block;
+  cursor: default;
+}
+
+.nav-label {
+  position: absolute;
+  top: 0;
+  left: 0;
+  padding: 0.35rem 0.75rem;
+  background: rgba(0, 0, 0, 0.85);
+  color: #fff;
+  font-size: 0.75rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  border-radius: 9999px;
+  border: 1px solid #000;
+  box-shadow: 0 0 0 2px #fff;
+  transform: translate(-50%, -50%);
+  transition: opacity 0.2s ease;
+  pointer-events: none;
+  white-space: nowrap;
+}
+
+@media (max-width: 768px) {
+  .nav-label {
+    font-size: 0.65rem;
+    letter-spacing: 0.1em;
+  }
 }

--- a/src/app/three-model/three-model.component.ts
+++ b/src/app/three-model/three-model.component.ts
@@ -1,138 +1,215 @@
 import { DOCUMENT, isPlatformBrowser } from '@angular/common';
-import { AfterViewInit, ApplicationRef, Component, ElementRef, Inject, NgZone, OnInit, PLATFORM_ID } from '@angular/core';
+import {
+  AfterViewInit,
+  Component,
+  ElementRef,
+  EventEmitter,
+  Inject,
+  NgZone,
+  OnDestroy,
+  OnInit,
+  Output,
+  PLATFORM_ID
+} from '@angular/core';
 import * as THREE from 'three';
 import { OBJLoader } from 'three-stdlib';
 import { Tween, Group, Easing } from '@tweenjs/tween.js';
 
+export type SectionKey = 'about' | 'resume' | 'portfolio' | 'wiki';
+
+export interface SectionEvent {
+  key: SectionKey;
+  label: string;
+}
+
+const NAV_TARGETS: Record<string, SectionEvent> = {
+  'Body1:1': { key: 'about', label: 'About' },
+  'Body1': { key: 'resume', label: 'Resume' },
+  'Body1:2': { key: 'wiki', label: 'Wiki' },
+  'Body1:3': { key: 'portfolio', label: 'Portfolio' }
+};
+
 @Component({
   selector: 'app-three-model',
-  standalone: true, // This marks it as a standalone component
+  standalone: true,
   templateUrl: './three-model.component.html',
   styleUrls: ['./three-model.component.css']
 })
-export class ThreeModelComponent implements OnInit, AfterViewInit {
+export class ThreeModelComponent implements OnInit, AfterViewInit, OnDestroy {
+  @Output() sectionFocus = new EventEmitter<SectionEvent>();
+  @Output() sectionReveal = new EventEmitter<SectionEvent>();
+
   private scene!: THREE.Scene;
-  private camera!: THREE.PerspectiveCamera | THREE.OrthographicCamera;
+  private camera!: THREE.OrthographicCamera;
   private renderer!: THREE.WebGLRenderer;
   private model!: THREE.Object3D;
-  private customLineMaterial!: THREE.ShaderMaterial;
   private isExploded = false;
-  private tweenGroup = new Group(); // Create a new Group for tweens
+  private tweenGroup = new Group();
+  private raycaster = new THREE.Raycaster();
+  private mouse = new THREE.Vector2();
+  private container!: HTMLElement;
+  private canvasEl!: HTMLCanvasElement;
+  private labelElement!: HTMLDivElement;
+  private hoveredMesh: THREE.Mesh | null = null;
+  private activeMesh: THREE.Mesh | null = null;
+  private navMeshes: THREE.Mesh[] = [];
+  private animationFrameId = 0;
+  private resizeListener?: () => void;
+  private detachFns: Array<() => void> = [];
+  private clock = new THREE.Clock();
+  private selectionInProgress = false;
 
   constructor(
-    private appRef: ApplicationRef,
     private el: ElementRef,
     private ngZone: NgZone,
     @Inject(DOCUMENT) private document: Document,
     @Inject(PLATFORM_ID) private platformId: Object
-  ) {
-    this.appRef.isStable.subscribe((isStable) => {
-      console.log(`Application is stable: ${isStable}`);
+  ) {}
+
+  ngOnInit(): void {}
+
+  ngAfterViewInit(): void {
+    if (!isPlatformBrowser(this.platformId)) {
+      return;
+    }
+
+    this.container = this.el.nativeElement.querySelector('#three-container');
+
+    this.ngZone.runOutsideAngular(() => {
+      this.initScene();
+      this.loadModel();
+      this.createLabel();
+      this.attachPointerEvents();
+      this.animate();
     });
   }
 
-  ngOnInit(): void {
-    console.log('ngOnInit called');
-  }
-
-  ngAfterViewInit(): void {
-    if (isPlatformBrowser(this.platformId)) {
-      this.ngZone.runOutsideAngular(() => {
-        this.initScene();
-        this.loadModel();
-        this.animate();
-      });
+  ngOnDestroy(): void {
+    if (!isPlatformBrowser(this.platformId)) {
+      return;
     }
-    this.onWindowResize();
 
-    // Attach toggleExplode to the container’s click event
-    const container = this.el.nativeElement.querySelector('#three-container');
-    container.addEventListener('click', () => this.toggleExplode());
+    this.detachFns.forEach((remove) => remove());
+    this.detachFns = [];
+
+    if (this.resizeListener) {
+      window.removeEventListener('resize', this.resizeListener);
+    }
+
+    cancelAnimationFrame(this.animationFrameId);
+    this.renderer?.dispose();
   }
 
+  resetSelection(): void {
+    if (!this.model) {
+      return;
+    }
+
+    const mesh = this.activeMesh;
+    this.activeMesh = null;
+
+    if (!mesh) {
+      this.setExploded(true);
+      return;
+    }
+
+    mesh.visible = true;
+    mesh.userData['fixedScale'] = true;
+    const originalPosition = (mesh.userData['originalPosition'] as THREE.Vector3).clone();
+    const baseScale = (mesh.userData['baseScale'] as THREE.Vector3).clone();
+    const material = mesh.material as THREE.MeshBasicMaterial;
+    const edgeLines = mesh.userData['edgeLines'] as THREE.LineSegments | undefined;
+    const edgeMaterial = mesh.userData['edgeMaterial'] as THREE.ShaderMaterial | undefined;
+
+    new Tween(mesh.position, this.tweenGroup)
+      .to({ x: originalPosition.x, y: originalPosition.y, z: originalPosition.z }, 800)
+      .easing(Easing.Cubic.Out)
+      .start();
+
+    const scaleData = { value: mesh.scale.x / baseScale.x };
+    new Tween(scaleData, this.tweenGroup)
+      .to({ value: 1 }, 600)
+      .easing(Easing.Cubic.Out)
+      .onUpdate(({ value }) => {
+        mesh.scale.set(baseScale.x * value, baseScale.y * value, baseScale.z * value);
+      })
+      .onComplete(() => {
+        mesh.userData['fixedScale'] = false;
+      })
+      .start();
+
+    new Tween({ opacity: material.opacity }, this.tweenGroup)
+      .to({ opacity: 1 }, 400)
+      .easing(Easing.Cubic.Out)
+      .onUpdate(({ opacity }) => {
+        material.opacity = opacity;
+        if (edgeMaterial) {
+          edgeMaterial.uniforms['lineOpacity'].value = opacity;
+        }
+      })
+      .onComplete(() => {
+        if (edgeLines) {
+          edgeLines.visible = true;
+        }
+      })
+      .start();
+
+    this.selectionInProgress = false;
+    this.setExploded(true);
+  }
 
   private initScene(): void {
-    if (typeof window === 'undefined') {
-      return; // Exit if window is not defined (e.g., in SSR)
-    }
-
     this.scene = new THREE.Scene();
 
-    // Orthographic Camera setup
-    const aspect = window.innerWidth / window.innerHeight;
+    const aspect = this.el.nativeElement.clientWidth / this.el.nativeElement.clientHeight || 1;
     const frustumSize = 10;
     this.camera = new THREE.OrthographicCamera(
-      frustumSize * aspect / -2,
-      frustumSize * aspect / 2,
+      (frustumSize * aspect) / -2,
+      (frustumSize * aspect) / 2,
       frustumSize / 2,
       frustumSize / -2,
       0.1,
       1000
     );
 
-    // Position the camera for an isometric view
-    this.camera.position.set(5, 5, 5); // Position for the opposite corner
-    this.camera.lookAt(0, 0, 0); // Keep it pointed at the center of the scene
+    this.camera.position.set(5, 5, 5);
+    this.camera.lookAt(0, 0, 0);
 
-    // Set renderer background color to Tailwind white
-    this.renderer = new THREE.WebGLRenderer({ antialias: true });
-    this.renderer.setClearColor(0xffffff); // Background color set to white
-    this.renderer.setSize(this.el.nativeElement.clientWidth * 0.25, this.el.nativeElement.clientHeight * 0.25);
+    this.renderer = new THREE.WebGLRenderer({ antialias: true, alpha: true });
+    this.renderer.setClearColor(0xffffff, 1);
+    this.renderer.setPixelRatio(window.devicePixelRatio);
+    this.container.appendChild(this.renderer.domElement);
 
-    const container = this.el.nativeElement.querySelector('#three-container');
-    container.appendChild(this.renderer.domElement);
-
-    // Optional: Add an ambient light for better visibility
-    const ambientLight = new THREE.AmbientLight(0x333333, 0.5); // Soft gray light
+    const ambientLight = new THREE.AmbientLight(0x333333, 0.7);
     this.scene.add(ambientLight);
 
-    window.addEventListener('resize', this.onWindowResize.bind(this));
+    this.canvasEl = this.renderer.domElement;
 
-    this.customLineMaterial = new THREE.ShaderMaterial({
-      uniforms: {
-        lineColor: { value: new THREE.Color(0x000000) },
-        scaleFactor: { value: 1.005 } // Controls the scale for boldness
-      },
-      vertexShader: `
-        uniform float scaleFactor;
-        void main() {
-          vec4 pos = modelViewMatrix * vec4(position * scaleFactor, 1.0);
-          pos.z -= 0.001; // Depth bias to bring edges slightly forward
-          gl_Position = projectionMatrix * pos;
-        }
-      `,
-      fragmentShader: `
-        uniform vec3 lineColor;
-        void main() {
-          gl_FragColor = vec4(lineColor, 1.0);
-        }
-      `,
-      depthTest: true,
-      depthWrite: false,
-      transparent: true
-    });
+    this.resizeListener = () => this.onWindowResize();
+    window.addEventListener('resize', this.resizeListener);
+    this.onWindowResize();
   }
 
   private onWindowResize(): void {
-    if (!this.renderer) {
+    if (!this.renderer || !this.camera || !this.container) {
       return;
     }
 
-    const container = this.el.nativeElement.querySelector('#three-container');
-    const size = Math.min(container.clientWidth, container.clientHeight);
-    this.renderer.setSize(size, size);
-
-    if (this.camera instanceof THREE.PerspectiveCamera) {
-      this.camera.aspect = 1;
-      this.camera.updateProjectionMatrix();
-    } else if (this.camera instanceof THREE.OrthographicCamera) {
-      const frustumSize = 10;
-      this.camera.left = frustumSize / -2;
-      this.camera.right = frustumSize / 2;
-      this.camera.top = frustumSize / 2;
-      this.camera.bottom = frustumSize / -2;
-      this.camera.updateProjectionMatrix();
+    const width = this.container.clientWidth;
+    const height = this.container.clientHeight;
+    if (width === 0 || height === 0) {
+      return;
     }
+
+    this.renderer.setSize(width, height, false);
+
+    const frustumSize = 10;
+    const aspect = width / height;
+    this.camera.left = (-frustumSize * aspect) / 2;
+    this.camera.right = (frustumSize * aspect) / 2;
+    this.camera.top = frustumSize / 2;
+    this.camera.bottom = -frustumSize / 2;
+    this.camera.updateProjectionMatrix();
   }
 
   private loadModel(): void {
@@ -142,102 +219,329 @@ export class ThreeModelComponent implements OnInit, AfterViewInit {
     loader.load(
       modelPath,
       (obj) => {
-        console.log("Model loaded successfully!");
         this.model = obj;
         this.model.rotation.z = Math.PI / 2;
-
         this.model.scale.set(0.25, 0.25, 0.25);
+
         const box = new THREE.Box3().setFromObject(this.model);
         const center = box.getCenter(new THREE.Vector3());
         this.model.position.sub(center);
 
+        this.navMeshes = [];
+
         this.model.traverse((child) => {
           if (child instanceof THREE.Mesh) {
-            child.material = new THREE.MeshBasicMaterial({ color: 0xFFFFFF });
+            const material = new THREE.MeshBasicMaterial({ color: 0xffffff, transparent: true, opacity: 1 });
+            child.material = material;
 
             const edgesGeometry = new THREE.EdgesGeometry(child.geometry);
-            const edgeLines = new THREE.LineSegments(edgesGeometry, this.customLineMaterial);
+            const edgeMaterial = this.createEdgeMaterial();
+            const edgeLines = new THREE.LineSegments(edgesGeometry, edgeMaterial);
             child.add(edgeLines);
+
+            child.userData['edgeLines'] = edgeLines;
+            child.userData['edgeMaterial'] = edgeMaterial;
+            child.userData['originalPosition'] = child.position.clone();
+            child.userData['baseScale'] = child.scale.clone();
+            child.userData['fixedScale'] = false;
+
+            if (NAV_TARGETS[child.name]) {
+              this.navMeshes.push(child);
+            }
           }
         });
 
         this.scene.add(this.model);
         this.prepareExplodeAnimation();
-
+        this.setExploded(true);
       },
       undefined,
       (error) => {
-        console.error("An error occurred loading the model:", error);
+        console.error('An error occurred loading the model:', error);
       }
     );
   }
 
+  private createEdgeMaterial(): THREE.ShaderMaterial {
+    return new THREE.ShaderMaterial({
+      uniforms: {
+        lineColor: { value: new THREE.Color(0x000000) },
+        scaleFactor: { value: 1.005 },
+        lineOpacity: { value: 1 }
+      },
+      vertexShader: `
+        uniform float scaleFactor;
+        void main() {
+          vec4 pos = modelViewMatrix * vec4(position * scaleFactor, 1.0);
+          pos.z -= 0.001;
+          gl_Position = projectionMatrix * pos;
+        }
+      `,
+      fragmentShader: `
+        uniform vec3 lineColor;
+        uniform float lineOpacity;
+        void main() {
+          gl_FragColor = vec4(lineColor, lineOpacity);
+        }
+      `,
+      depthTest: true,
+      depthWrite: false,
+      transparent: true
+    });
+  }
 
+  private prepareExplodeAnimation(): void {
+    if (!this.model) {
+      return;
+    }
+
+    this.model.traverse((child) => {
+      if (!(child instanceof THREE.Mesh)) {
+        return;
+      }
+
+      const originalPosition = child.userData['originalPosition'] as THREE.Vector3;
+      if (!originalPosition) {
+        child.userData['originalPosition'] = child.position.clone();
+      }
+
+      let explodedPosition = child.position.clone();
+      switch (child.name) {
+        case 'Body1':
+          explodedPosition = child.position.clone().add(new THREE.Vector3(0, 0, 12));
+          break;
+        case 'Body1:2':
+          explodedPosition = child.position.clone().add(new THREE.Vector3(12, 0, 0));
+          break;
+        case 'Body1:3':
+          explodedPosition = child.position.clone().add(new THREE.Vector3(0, -12, 0));
+          break;
+        default:
+          explodedPosition = child.position.clone();
+      }
+
+      child.userData['tweenExplode'] = new Tween(child.position, this.tweenGroup)
+        .to({ x: explodedPosition.x, y: explodedPosition.y, z: explodedPosition.z }, 1000)
+        .easing(Easing.Cubic.Out);
+
+      child.userData['tweenImplode'] = new Tween(child.position, this.tweenGroup)
+        .to({ x: child.userData['originalPosition'].x, y: child.userData['originalPosition'].y, z: child.userData['originalPosition'].z }, 1000)
+        .easing(Easing.Cubic.Out);
+    });
+  }
+
+  private setExploded(desired: boolean): void {
+    if (!this.model || this.isExploded === desired) {
+      return;
+    }
+
+    this.model.traverse((child) => {
+      if (child instanceof THREE.Mesh) {
+        const tweenKey = desired ? 'tweenExplode' : 'tweenImplode';
+        const tween: Tween<THREE.Vector3> | undefined = child.userData[tweenKey];
+        if (tween) {
+          tween.stop();
+          tween.start();
+        }
+      }
+    });
+
+    this.isExploded = desired;
+  }
+
+  private attachPointerEvents(): void {
+    if (!this.canvasEl) {
+      return;
+    }
+
+    const moveHandler = (event: PointerEvent) => this.handlePointerMove(event);
+    const leaveHandler = () => this.handlePointerLeave();
+    const clickHandler = () => this.handlePointerClick();
+
+    this.canvasEl.addEventListener('pointermove', moveHandler);
+    this.canvasEl.addEventListener('pointerleave', leaveHandler);
+    this.canvasEl.addEventListener('click', clickHandler);
+
+    this.detachFns.push(() => this.canvasEl.removeEventListener('pointermove', moveHandler));
+    this.detachFns.push(() => this.canvasEl.removeEventListener('pointerleave', leaveHandler));
+    this.detachFns.push(() => this.canvasEl.removeEventListener('click', clickHandler));
+  }
+
+  private handlePointerMove(event: PointerEvent): void {
+    if (!this.model || !this.isExploded || this.selectionInProgress) {
+      return;
+    }
+
+    const rect = this.canvasEl.getBoundingClientRect();
+    this.mouse.x = ((event.clientX - rect.left) / rect.width) * 2 - 1;
+    this.mouse.y = -((event.clientY - rect.top) / rect.height) * 2 + 1;
+
+    this.raycaster.setFromCamera(this.mouse, this.camera);
+    const intersections = this.raycaster.intersectObjects(this.navMeshes, false);
+    const mesh = intersections.length > 0 ? (intersections[0].object as THREE.Mesh) : null;
+
+    if (mesh !== this.hoveredMesh) {
+      this.hoveredMesh = mesh;
+      this.updateHoverAppearance();
+    }
+  }
+
+  private handlePointerLeave(): void {
+    if (!this.hoveredMesh) {
+      return;
+    }
+    this.hoveredMesh = null;
+    this.updateHoverAppearance();
+  }
+
+  private handlePointerClick(): void {
+    if (!this.hoveredMesh || !this.isExploded || this.selectionInProgress) {
+      return;
+    }
+
+    const config = NAV_TARGETS[this.hoveredMesh.name];
+    if (!config) {
+      return;
+    }
+
+    this.startSelection(this.hoveredMesh, config);
+  }
+
+  private startSelection(mesh: THREE.Mesh, config: SectionEvent): void {
+    this.selectionInProgress = true;
+    this.activeMesh = mesh;
+    this.hoveredMesh = null;
+    this.updateHoverAppearance();
+
+    mesh.userData['fixedScale'] = true;
+
+    const parent = mesh.parent as THREE.Object3D;
+    const targetWorld = new THREE.Vector3(0, 0, 2.5);
+    const targetPosition = parent.worldToLocal(targetWorld.clone());
+    const baseScale = mesh.userData['baseScale'] as THREE.Vector3;
+    const material = mesh.material as THREE.MeshBasicMaterial;
+    const edgeMaterial = mesh.userData['edgeMaterial'] as THREE.ShaderMaterial | undefined;
+    const edgeLines = mesh.userData['edgeLines'] as THREE.LineSegments | undefined;
+
+    this.sectionFocus.emit(config);
+
+    new Tween(mesh.position, this.tweenGroup)
+      .to({ x: targetPosition.x, y: targetPosition.y, z: targetPosition.z }, 850)
+      .easing(Easing.Cubic.Out)
+      .start();
+
+    const scaleData = { value: 1 };
+    new Tween(scaleData, this.tweenGroup)
+      .to({ value: 1.6 }, 700)
+      .easing(Easing.Cubic.Out)
+      .onUpdate(({ value }) => {
+        mesh.scale.set(baseScale.x * value, baseScale.y * value, baseScale.z * value);
+      })
+      .start();
+
+    if (edgeLines) {
+      edgeLines.visible = false;
+    }
+
+    new Tween({ opacity: material.opacity }, this.tweenGroup)
+      .to({ opacity: 0 }, 650)
+      .delay(550)
+      .easing(Easing.Cubic.In)
+      .onUpdate(({ opacity }) => {
+        material.opacity = opacity;
+        if (edgeMaterial) {
+          edgeMaterial.uniforms['lineOpacity'].value = opacity;
+        }
+      })
+      .onComplete(() => {
+        mesh.visible = false;
+        this.selectionInProgress = false;
+        this.sectionReveal.emit(config);
+      })
+      .start();
+  }
+
+  private updateHoverAppearance(): void {
+    if (!this.canvasEl) {
+      return;
+    }
+
+    if (this.hoveredMesh && this.isExploded && !this.selectionInProgress) {
+      this.canvasEl.style.cursor = 'pointer';
+    } else {
+      this.canvasEl.style.cursor = 'default';
+    }
+
+    if (!this.labelElement) {
+      return;
+    }
+
+    if (!this.hoveredMesh) {
+      this.labelElement.style.opacity = '0';
+      return;
+    }
+
+    const config = NAV_TARGETS[this.hoveredMesh.name];
+    if (!config) {
+      this.labelElement.style.opacity = '0';
+      return;
+    }
+
+    this.labelElement.textContent = config.label;
+    this.labelElement.style.opacity = '1';
+  }
+
+  private updateLabelPosition(): void {
+    if (!this.hoveredMesh || !this.labelElement) {
+      return;
+    }
+
+    const vector = new THREE.Vector3();
+    this.hoveredMesh.getWorldPosition(vector);
+    vector.project(this.camera);
+
+    const rect = this.canvasEl.getBoundingClientRect();
+    const x = ((vector.x + 1) / 2) * rect.width;
+    const y = ((-vector.y + 1) / 2) * rect.height;
+
+    this.labelElement.style.transform = `translate(-50%, -50%) translate(${x}px, ${y}px)`;
+  }
+
+  private createLabel(): void {
+    this.labelElement = this.document.createElement('div');
+    this.labelElement.className = 'nav-label';
+    this.labelElement.style.opacity = '0';
+    this.container.appendChild(this.labelElement);
+  }
 
   private animate(): void {
-    requestAnimationFrame(() => this.animate());
-    this.tweenGroup.update(performance.now());  // Update the group with the current time
+    this.animationFrameId = requestAnimationFrame(() => this.animate());
+
+    if (!this.renderer || !this.scene || !this.camera) {
+      return;
+    }
+
+    this.tweenGroup.update(performance.now());
+    this.updatePulse();
+    this.updateLabelPosition();
     this.renderer.render(this.scene, this.camera);
   }
 
-
-
-  private prepareExplodeAnimation(): void {
-    this.model.traverse((child) => {
-      if (child instanceof THREE.Mesh) {
-        // Skip the large part ("Body1:1") and only set up explosion for smaller parts
-        if (child.name === 'Body1:1') {
-          console.log(`Skipping explosion setup for large part: ${child.name}`);
-          return;
-        }
-
-        console.log(`Setting up explosion for small part: ${child.name}`);
-        child.userData['originalPosition'] = child.position.clone();
-
-        // Define explosion direction for each smaller part
-        let explodedPosition;
-        switch (child.name) {
-          case 'Body1':
-            explodedPosition = child.position.clone().add(new THREE.Vector3(0, 0, 12)); // Move along x-axis
-            break;
-          case 'Body1:2':
-            explodedPosition = child.position.clone().add(new THREE.Vector3(12, 0, 0)); // Move along y-axis
-            break;
-          case 'Body1:3':
-            explodedPosition = child.position.clone().add(new THREE.Vector3(0, -12, 0)); // Move along z-axis
-            break;
-          default:
-            explodedPosition = child.position.clone(); // Fallback, no movement
-        }
-
-        // Create tweens for the explosion and implosion
-        child.userData['tweenExplode'] = new Tween(child.position, this.tweenGroup)
-          .to({ x: explodedPosition.x, y: explodedPosition.y, z: explodedPosition.z }, 1000)
-          .easing(Easing.Cubic.Out);
-
-        child.userData['tweenImplode'] = new Tween(child.position, this.tweenGroup)
-          .to({ x: child.userData['originalPosition'].x, y: child.userData['originalPosition'].y, z: child.userData['originalPosition'].z }, 1000)
-          .easing(Easing.Cubic.Out);
+  private updatePulse(): void {
+    const elapsed = this.clock.getElapsedTime();
+    for (const mesh of this.navMeshes) {
+      if (mesh === this.activeMesh || mesh.userData['fixedScale']) {
+        continue;
       }
-    });
-  }
 
-
-
-
-
-
-  private toggleExplode(): void {
-    this.model.traverse((child) => {
-      if (child instanceof THREE.Mesh && child.userData['tweenExplode'] && child.userData['tweenImplode']) {
-        if (!this.isExploded) {
-          child.userData['tweenExplode'].start();
-        } else {
-          child.userData['tweenImplode'].start();
-        }
+      const baseScale = mesh.userData['baseScale'] as THREE.Vector3;
+      if (!baseScale) {
+        continue;
       }
-    });
-    this.isExploded = !this.isExploded; // Toggle the explosion state
-  }
 
+      const amplitude = mesh === this.hoveredMesh ? 0.06 : 0.03;
+      const pulse = 1 + amplitude * Math.sin(elapsed * 2 + mesh.id * 0.5);
+      mesh.scale.set(baseScale.x * pulse, baseScale.y * pulse, baseScale.z * pulse);
+    }
+  }
 }

--- a/src/app/wiki/wiki.component.css
+++ b/src/app/wiki/wiki.component.css
@@ -1,0 +1,133 @@
+:host {
+  display: block;
+  color: #111827;
+}
+
+.wiki-layout {
+  display: grid;
+  grid-template-columns: minmax(12rem, 18rem) 1fr;
+  gap: 1.5rem;
+}
+
+.wiki-nav {
+  border: 2px solid #111827;
+  padding: 1rem;
+  background: #f3f4f6;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.wiki-nav h2 {
+  margin: 0;
+  font-size: 0.85rem;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+}
+
+.wiki-nav ul {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.wiki-nav li button {
+  width: 100%;
+  border: 2px solid #111827;
+  background: #fff;
+  padding: 0.75rem;
+  text-align: left;
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  transition: background-color 0.3s ease, color 0.3s ease;
+}
+
+.wiki-nav li.active button,
+.wiki-nav li button:hover,
+.wiki-nav li button:focus {
+  background: #111827;
+  color: #fff;
+}
+
+.wiki-nav .title {
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  font-size: 0.85rem;
+}
+
+.wiki-nav .description {
+  font-size: 0.75rem;
+  line-height: 1.4;
+}
+
+.wiki-content {
+  border: 2px solid #111827;
+  padding: 1.5rem;
+  background: #ffffff;
+  overflow-y: auto;
+  max-height: 60vh;
+}
+
+.status {
+  font-size: 0.9rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.status--error {
+  color: #b91c1c;
+}
+
+.markdown h1,
+.markdown h2,
+.markdown h3 {
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  margin-top: 1.5rem;
+}
+
+.markdown h1 {
+  font-size: 1.6rem;
+}
+
+.markdown h2 {
+  font-size: 1.2rem;
+}
+
+.markdown h3 {
+  font-size: 1rem;
+}
+
+.markdown p,
+.markdown li {
+  line-height: 1.6;
+  margin-bottom: 1rem;
+}
+
+.markdown pre {
+  padding: 1rem;
+  background: #111827;
+  color: #f8fafc;
+  overflow-x: auto;
+}
+
+.markdown a {
+  color: #2563eb;
+  text-decoration: underline;
+}
+
+@media (max-width: 960px) {
+  .wiki-layout {
+    grid-template-columns: 1fr;
+  }
+
+  .wiki-content {
+    max-height: none;
+  }
+}

--- a/src/app/wiki/wiki.component.html
+++ b/src/app/wiki/wiki.component.html
@@ -1,1 +1,25 @@
-<p>wiki works!</p>
+<section class="wiki-layout">
+  <aside class="wiki-nav">
+    <h2>Documents</h2>
+    <ul>
+      <li
+        *ngFor="let entry of entries()"
+        [class.active]="activeDoc()?.entry?.file === entry.file"
+      >
+        <button type="button" (click)="loadDoc(entry)">
+          <span class="title">{{ entry.title }}</span>
+          <span class="description">{{ entry.description }}</span>
+        </button>
+      </li>
+    </ul>
+  </aside>
+  <article class="wiki-content" (click)="handleContentClick($event)">
+    <div *ngIf="loading()" class="status">Loading documentation&hellip;</div>
+    <div *ngIf="!loading() && error()" class="status status--error">{{ error() }}</div>
+    <div
+      *ngIf="!loading() && !error() && activeDoc()"
+      class="markdown"
+      [innerHTML]="activeDoc()?.content"
+    ></div>
+  </article>
+</section>

--- a/src/app/wiki/wiki.component.ts
+++ b/src/app/wiki/wiki.component.ts
@@ -1,12 +1,110 @@
-import { Component } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { Component, OnInit, signal } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { DomSanitizer, SafeHtml } from '@angular/platform-browser';
+import { marked } from 'marked';
+
+type WikiEntry = {
+  title: string;
+  description: string;
+  file: string;
+};
+
+type WikiDocument = {
+  entry: WikiEntry;
+  content: SafeHtml;
+};
 
 @Component({
   selector: 'app-wiki',
   standalone: true,
-  imports: [],
+  imports: [CommonModule],
   templateUrl: './wiki.component.html',
   styleUrls: ['./wiki.component.css']
 })
-export class WikiComponent {
+export class WikiComponent implements OnInit {
+  readonly entries = signal<WikiEntry[]>([]);
+  readonly activeDoc = signal<WikiDocument | null>(null);
+  readonly loading = signal(false);
+  readonly error = signal<string | null>(null);
 
+  constructor(private http: HttpClient, private sanitizer: DomSanitizer) {
+    const renderer = new marked.Renderer();
+    renderer.link = (href, title, text) => {
+      if (!href) {
+        return text;
+      }
+
+      const isRelative = !/^(https?:)?\/\//.test(href) && !href.startsWith('#');
+      const escapedText = text ?? href;
+      const titleAttr = title ? ` title="${title}"` : '';
+
+      if (isRelative) {
+        const safeHref = href.replace(/"/g, '&quot;');
+        return `<a href="#" data-doc="${safeHref}"${titleAttr}>${escapedText}</a>`;
+      }
+
+      return `<a href="${href}" target="_blank" rel="noopener"${titleAttr}>${escapedText}</a>`;
+    };
+
+    marked.setOptions({ renderer, breaks: true });
+  }
+
+  ngOnInit(): void {
+    this.fetchManifest();
+  }
+
+  fetchManifest(): void {
+    this.loading.set(true);
+    this.http.get<WikiEntry[]>('docs/manifest.json').subscribe({
+      next: (entries) => {
+        this.entries.set(entries);
+        this.loading.set(false);
+        this.error.set(null);
+        if (entries.length > 0) {
+          this.loadDoc(entries[0]);
+        }
+      },
+      error: () => {
+        this.error.set('Unable to load wiki manifest.');
+        this.loading.set(false);
+      }
+    });
+  }
+
+  loadDoc(entry: WikiEntry): void {
+    this.loading.set(true);
+    this.error.set(null);
+    this.http
+      .get(`docs/${entry.file}`, { responseType: 'text' })
+      .subscribe({
+        next: (markdown) => {
+          const html = marked.parse(markdown) as string;
+          this.activeDoc.set({ entry, content: this.sanitizer.bypassSecurityTrustHtml(html) });
+          this.loading.set(false);
+        },
+        error: () => {
+          this.error.set('Unable to load document.');
+          this.loading.set(false);
+        }
+      });
+  }
+
+  handleContentClick(event: MouseEvent): void {
+    const target = (event.target as HTMLElement).closest('a[data-doc]');
+    if (!target) {
+      return;
+    }
+
+    event.preventDefault();
+    const file = target.getAttribute('data-doc');
+    if (!file) {
+      return;
+    }
+
+    const entry = this.entries().find((item) => item.file === file);
+    if (entry) {
+      this.loadDoc(entry);
+    }
+  }
 }

--- a/src/docs/manifest.json
+++ b/src/docs/manifest.json
@@ -1,0 +1,12 @@
+[
+  {
+    "title": "Architecture Overview",
+    "description": "High-level view of the mechanical portfolio site.",
+    "file": "ARCHITECTURE.md"
+  },
+  {
+    "title": "3D Model Guide",
+    "description": "Details about interacting with the 3D cube system.",
+    "file": "THREE-MODEL-GUIDE.md"
+  }
+]


### PR DESCRIPTION
## Summary
- wire the exploded cube to drive navigation with hover labels, focus animations, and overlay handoff to the router content
- add styled placeholder content for the about, resume, and portfolio routes that appears after a cube fades out
- build a wiki reader that loads markdown entries from the new docs manifest and renders them with in-app navigation

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ca4a33f848832db21d607f1d004a40