### PR TITLE
Improve 3D navigation interactions

### DIFF
--- a/src/app/app.component.css
+++ b/src/app/app.component.css
@@ -1,5 +1,21 @@
+:host {
+  display: block;
+  height: 100%;
+}
+
 .three-container-wrapper {
   position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  height: 100%;
+  min-height: 0;
+}
+
+.three-container-wrapper app-three-model {
+  flex: 1 1 auto;
+  height: 100%;
 }
 
 .content-overlay {

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -71,7 +71,7 @@
   <!-- Main Content Area -->
 
   <!-- 3d model rendering -->
-  <div class="three-container-wrapper relative z-0 w-full h-[80vh] overflow-hidden">
+  <div class="three-container-wrapper relative z-0 flex-1 min-h-0 overflow-hidden">
     <app-three-model
       #threeModel
       (sectionFocus)="handleSectionFocus($event)"

--- a/src/app/three-model/three-model.component.css
+++ b/src/app/three-model/three-model.component.css
@@ -1,3 +1,9 @@
+:host {
+  display: block;
+  width: 100%;
+  height: 100%;
+}
+
 .three-container {
   position: relative;
   width: 100%;
@@ -21,17 +27,19 @@
   position: absolute;
   top: 0;
   left: 0;
-  padding: 0.35rem 0.75rem;
-  background: rgba(0, 0, 0, 0.85);
-  color: #fff;
+  padding: 0.4rem 0.8rem;
+  background: #fff;
+  color: #000;
   font-size: 0.75rem;
-  letter-spacing: 0.12em;
+  font-weight: 600;
+  letter-spacing: 0.15em;
   text-transform: uppercase;
-  border-radius: 9999px;
-  border: 1px solid #000;
-  box-shadow: 0 0 0 2px #fff;
+  line-height: 1.2;
+  border-radius: 0.5rem;
+  border: 2px solid #000;
+  box-shadow: 4px 4px 0 0 #000;
   transform: translate(-50%, -50%);
-  transition: opacity 0.2s ease;
+  transition: opacity 0.2s ease, transform 0.2s ease;
   pointer-events: none;
   white-space: nowrap;
 }


### PR DESCRIPTION
## Summary
- keep the Three.js viewport centered by resizing the container to fill the layout and delaying a recenter after the explode animation
- polish the hover and selection experience: tooltips now match the site styling, hover pulsing only occurs on the focused mesh, and selections spin, scale, and fade surrounding meshes before revealing content
- add reset animations so returning from a section restores mesh opacity, rotation, and scale smoothly

## Testing
- `npm run build` *(fails: local Node 22.x violates the repository engine constraint)*

------
https://chatgpt.com/codex/tasks/task_e_68ccecf20d2c832d828fa0e03db04ea5