### PR TITLE
Refine cube viewport and reveal flow

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -71,7 +71,7 @@
   <!-- Main Content Area -->
 
   <!-- 3d model rendering -->
-  <div class="three-container-wrapper relative z-0 w-full h-[80vh] overflow-hidden">
+  <div class="three-container-wrapper relative z-0 w-full h-full flex items-center justify-center overflow-hidden">
     <app-three-model
       #threeModel
       (sectionFocus)="handleSectionFocus($event)"

--- a/src/app/three-model/three-model.component.css
+++ b/src/app/three-model/three-model.component.css
@@ -1,3 +1,9 @@
+:host {
+  display: block;
+  width: 100%;
+  height: 100%;
+}
+
 .three-container {
   position: relative;
   width: 100%;
@@ -19,26 +25,69 @@
 
 .nav-label {
   position: absolute;
-  top: 0;
-  left: 0;
-  padding: 0.35rem 0.75rem;
-  background: rgba(0, 0, 0, 0.85);
-  color: #fff;
-  font-size: 0.75rem;
-  letter-spacing: 0.12em;
-  text-transform: uppercase;
-  border-radius: 9999px;
-  border: 1px solid #000;
-  box-shadow: 0 0 0 2px #fff;
-  transform: translate(-50%, -50%);
-  transition: opacity 0.2s ease;
+  min-width: 12rem;
+  padding: 0.75rem 1rem 0.85rem;
+  background: #ffffff;
+  color: #000000;
+  border: 2px solid #000000;
+  box-shadow: 6px 6px 0 #000000;
+  transform: translate(-50%, -100%);
+  transition: opacity 0.2s ease, transform 0.2s ease;
   pointer-events: none;
-  white-space: nowrap;
+  white-space: normal;
+  text-align: left;
+  z-index: 2;
+}
+
+.nav-label::after,
+.nav-label::before {
+  content: '';
+  position: absolute;
+  left: 50%;
+  transform: translateX(-50%);
+}
+
+.nav-label::after {
+  bottom: -14px;
+  border-width: 12px 12px 0 12px;
+  border-style: solid;
+  border-color: #000000 transparent transparent transparent;
+}
+
+.nav-label::before {
+  bottom: -11px;
+  border-width: 10px 10px 0 10px;
+  border-style: solid;
+  border-color: #ffffff transparent transparent transparent;
+}
+
+.nav-label__title {
+  display: block;
+  font-weight: 700;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  font-size: 0.75rem;
+}
+
+.nav-label__body {
+  margin: 0.35rem 0 0;
+  font-size: 0.7rem;
+  letter-spacing: 0.03em;
+  line-height: 1.3;
 }
 
 @media (max-width: 768px) {
   .nav-label {
+    min-width: 10rem;
+    padding: 0.6rem 0.75rem 0.7rem;
+    box-shadow: 4px 4px 0 #000000;
+  }
+
+  .nav-label__title {
+    font-size: 0.7rem;
+  }
+
+  .nav-label__body {
     font-size: 0.65rem;
-    letter-spacing: 0.1em;
   }
 }

--- a/src/app/three-model/three-model.component.ts
+++ b/src/app/three-model/three-model.component.ts
@@ -20,13 +20,14 @@ export type SectionKey = 'about' | 'resume' | 'portfolio' | 'wiki';
 export interface SectionEvent {
   key: SectionKey;
   label: string;
+  description: string;
 }
 
 const NAV_TARGETS: Record<string, SectionEvent> = {
-  'Body1:1': { key: 'about', label: 'About' },
-  'Body1': { key: 'resume', label: 'Resume' },
-  'Body1:2': { key: 'wiki', label: 'Wiki' },
-  'Body1:3': { key: 'portfolio', label: 'Portfolio' }
+  'Body1:1': { key: 'about', label: 'About', description: 'Meet the storyteller and the practice.' },
+  'Body1': { key: 'resume', label: 'Resume', description: 'Review experience, skills, and accolades.' },
+  'Body1:2': { key: 'wiki', label: 'Wiki', description: 'Explore ongoing research, notes, and ideas.' },
+  'Body1:3': { key: 'portfolio', label: 'Portfolio', description: 'Dive into selected projects and case studies.' }
 };
 
 @Component({
@@ -50,6 +51,8 @@ export class ThreeModelComponent implements OnInit, AfterViewInit, OnDestroy {
   private container!: HTMLElement;
   private canvasEl!: HTMLCanvasElement;
   private labelElement!: HTMLDivElement;
+  private labelTitleEl!: HTMLSpanElement;
+  private labelBodyEl!: HTMLParagraphElement;
   private hoveredMesh: THREE.Mesh | null = null;
   private activeMesh: THREE.Mesh | null = null;
   private navMeshes: THREE.Mesh[] = [];
@@ -64,6 +67,8 @@ export class ThreeModelComponent implements OnInit, AfterViewInit, OnDestroy {
   private cameraDirection = new THREE.Vector3(1, 1, 1).normalize();
   private sceneRadius = 1;
   private tempVector = new THREE.Vector3();
+  private scaleVector = new THREE.Vector3();
+  private recenterPending = false;
 
   constructor(
     private el: ElementRef,
@@ -111,11 +116,15 @@ export class ThreeModelComponent implements OnInit, AfterViewInit, OnDestroy {
       return;
     }
 
+    this.hoveredMesh = null;
+    this.updateHoverAppearance();
+
     const mesh = this.activeMesh;
     this.activeMesh = null;
 
     if (!mesh) {
       this.setExploded(true);
+      this.recenterPending = true;
       return;
     }
 
@@ -123,9 +132,45 @@ export class ThreeModelComponent implements OnInit, AfterViewInit, OnDestroy {
     mesh.userData['fixedScale'] = true;
     const originalPosition = (mesh.userData['originalPosition'] as THREE.Vector3).clone();
     const baseScale = (mesh.userData['baseScale'] as THREE.Vector3).clone();
+    const baseRotation = mesh.userData['baseRotation'] as THREE.Euler | undefined;
     const material = mesh.material as THREE.MeshBasicMaterial;
     const edgeLines = mesh.userData['edgeLines'] as THREE.LineSegments | undefined;
     const edgeMaterial = mesh.userData['edgeMaterial'] as THREE.ShaderMaterial | undefined;
+
+    const otherMeshes = this.navMeshes.filter((candidate) => candidate !== mesh);
+
+    for (const other of otherMeshes) {
+      other.visible = true;
+      const otherMaterial = other.material as THREE.MeshBasicMaterial;
+      const otherEdgeMaterial = other.userData['edgeMaterial'] as THREE.ShaderMaterial | undefined;
+      const otherEdgeLines = other.userData['edgeLines'] as THREE.LineSegments | undefined;
+      const otherBaseScale = other.userData['baseScale'] as THREE.Vector3 | undefined;
+      other.userData['fixedScale'] = false;
+
+      if (otherBaseScale) {
+        other.scale.copy(otherBaseScale);
+      }
+
+      if (otherEdgeLines) {
+        otherEdgeLines.visible = true;
+      }
+
+      otherMaterial.opacity = 0;
+      if (otherEdgeMaterial) {
+        otherEdgeMaterial.uniforms['lineOpacity'].value = 0;
+      }
+
+      new Tween({ opacity: otherMaterial.opacity }, this.tweenGroup)
+        .to({ opacity: 1 }, 450)
+        .easing(Easing.Cubic.Out)
+        .onUpdate(({ opacity }) => {
+          otherMaterial.opacity = opacity;
+          if (otherEdgeMaterial) {
+            otherEdgeMaterial.uniforms['lineOpacity'].value = opacity;
+          }
+        })
+        .start();
+    }
 
     new Tween(mesh.position, this.tweenGroup)
       .to({ x: originalPosition.x, y: originalPosition.y, z: originalPosition.z }, 800)
@@ -157,11 +202,15 @@ export class ThreeModelComponent implements OnInit, AfterViewInit, OnDestroy {
         if (edgeLines) {
           edgeLines.visible = true;
         }
+        if (baseRotation) {
+          mesh.rotation.copy(baseRotation);
+        }
       })
       .start();
 
     this.selectionInProgress = false;
     this.setExploded(true);
+    this.recenterPending = true;
   }
 
   private initScene(): void {
@@ -189,7 +238,7 @@ export class ThreeModelComponent implements OnInit, AfterViewInit, OnDestroy {
 
     this.renderer = new THREE.WebGLRenderer({ antialias: true, alpha: true });
     this.renderer.setClearColor(0xffffff, 1);
-    this.renderer.setPixelRatio(window.devicePixelRatio);
+    this.renderer.setPixelRatio(Math.min(window.devicePixelRatio, 2));
     this.container.appendChild(this.renderer.domElement);
 
     const ambientLight = new THREE.AmbientLight(0x333333, 0.7);
@@ -230,8 +279,8 @@ export class ThreeModelComponent implements OnInit, AfterViewInit, OnDestroy {
 
     const radius = Math.max(this.sceneRadius, 1);
     const aspect = viewWidth / viewHeight;
-    const padding = 1.35;
-    const halfSize = radius * padding;
+    const verticalFill = viewWidth < 768 ? 0.62 : 0.48;
+    const halfSize = radius / verticalFill;
 
     this.camera.left = -halfSize * aspect;
     this.camera.right = halfSize * aspect;
@@ -239,25 +288,29 @@ export class ThreeModelComponent implements OnInit, AfterViewInit, OnDestroy {
     this.camera.bottom = -halfSize;
     this.camera.updateProjectionMatrix();
 
-    const distance = radius * 2.6;
+    const distance = radius * 3.4;
     this.tempVector.copy(this.cameraDirection).multiplyScalar(distance);
     this.camera.position.copy(this.tempVector);
     this.camera.lookAt(0, 0, 0);
   }
 
-  private recenterAndFrameModel(force = false): void {
+  private recenterAndFrameModel(force = false): boolean {
     if (!this.model || !this.camera) {
-      return;
+      return false;
     }
 
-    if (this.selectionInProgress && !force) {
-      return;
+    if ((this.selectionInProgress || this.hoveredMesh || this.activeMesh) && !force) {
+      return false;
+    }
+
+    if (!force && this.tweenGroup.getAll().length > 0) {
+      return false;
     }
 
     this.model.updateMatrixWorld(true);
     this.boundingBox.setFromObject(this.model);
     if (this.boundingBox.isEmpty()) {
-      return;
+      return false;
     }
 
     this.boundingBox.getCenter(this.modelCenter);
@@ -266,7 +319,7 @@ export class ThreeModelComponent implements OnInit, AfterViewInit, OnDestroy {
       !Number.isFinite(this.modelCenter.y) ||
       !Number.isFinite(this.modelCenter.z)
     ) {
-      return;
+      return false;
     }
 
     if (this.modelCenter.lengthSq() > 1e-6) {
@@ -277,17 +330,14 @@ export class ThreeModelComponent implements OnInit, AfterViewInit, OnDestroy {
     this.boundingBox.setFromObject(this.model);
     this.boundingBox.getBoundingSphere(this.boundingSphere);
     if (!Number.isFinite(this.boundingSphere.radius) || this.boundingSphere.radius <= 0) {
-      return;
+      return false;
     }
 
     const normalizedRadius = Math.max(this.boundingSphere.radius, 1);
-    if (force) {
-      this.sceneRadius = normalizedRadius;
-    } else {
-      this.sceneRadius = Math.max(this.sceneRadius, normalizedRadius);
-    }
+    this.sceneRadius = normalizedRadius * 1.18;
 
     this.updateCameraFrustum();
+    return true;
   }
 
   private loadModel(): void {
@@ -308,6 +358,10 @@ export class ThreeModelComponent implements OnInit, AfterViewInit, OnDestroy {
             const material = new THREE.MeshBasicMaterial({ color: 0xffffff, transparent: true, opacity: 1 });
             child.material = material;
 
+            if (!child.geometry.boundingBox) {
+              child.geometry.computeBoundingBox();
+            }
+
             const edgesGeometry = new THREE.EdgesGeometry(child.geometry);
             const edgeMaterial = this.createEdgeMaterial();
             const edgeLines = new THREE.LineSegments(edgesGeometry, edgeMaterial);
@@ -317,6 +371,7 @@ export class ThreeModelComponent implements OnInit, AfterViewInit, OnDestroy {
             child.userData['edgeMaterial'] = edgeMaterial;
             child.userData['originalPosition'] = child.position.clone();
             child.userData['baseScale'] = child.scale.clone();
+            child.userData['baseRotation'] = child.rotation.clone();
             child.userData['fixedScale'] = false;
 
             if (NAV_TARGETS[child.name]) {
@@ -329,6 +384,7 @@ export class ThreeModelComponent implements OnInit, AfterViewInit, OnDestroy {
         this.recenterAndFrameModel(true);
         this.prepareExplodeAnimation();
         this.setExploded(true);
+        this.recenterPending = true;
       },
       undefined,
       (error) => {
@@ -422,6 +478,7 @@ export class ThreeModelComponent implements OnInit, AfterViewInit, OnDestroy {
     });
 
     this.isExploded = desired;
+    this.recenterPending = true;
   }
 
   private attachPointerEvents(): void {
@@ -491,14 +548,50 @@ export class ThreeModelComponent implements OnInit, AfterViewInit, OnDestroy {
     mesh.userData['fixedScale'] = true;
 
     const parent = mesh.parent as THREE.Object3D;
-    const targetWorld = new THREE.Vector3(0, 0, 2.5);
+    parent.updateMatrixWorld(true);
+
+    const focusDistance = this.sceneRadius * 0.65;
+    const targetWorld = this.cameraDirection.clone().multiplyScalar(focusDistance);
     const targetPosition = parent.worldToLocal(targetWorld.clone());
     const baseScale = mesh.userData['baseScale'] as THREE.Vector3;
+    const baseRotation = mesh.userData['baseRotation'] as THREE.Euler | undefined;
     const material = mesh.material as THREE.MeshBasicMaterial;
     const edgeMaterial = mesh.userData['edgeMaterial'] as THREE.ShaderMaterial | undefined;
     const edgeLines = mesh.userData['edgeLines'] as THREE.LineSegments | undefined;
 
-    this.sectionFocus.emit(config);
+    const otherMeshes = this.navMeshes.filter((candidate) => candidate !== mesh);
+
+    for (const other of otherMeshes) {
+      const otherMaterial = other.material as THREE.MeshBasicMaterial;
+      const otherEdgeMaterial = other.userData['edgeMaterial'] as THREE.ShaderMaterial | undefined;
+      const otherEdgeLines = other.userData['edgeLines'] as THREE.LineSegments | undefined;
+      const otherBaseScale = other.userData['baseScale'] as THREE.Vector3 | undefined;
+      other.userData['fixedScale'] = true;
+
+      if (otherBaseScale) {
+        other.scale.copy(otherBaseScale);
+      }
+
+      new Tween({ opacity: otherMaterial.opacity }, this.tweenGroup)
+        .to({ opacity: 0 }, 420)
+        .easing(Easing.Cubic.InOut)
+        .onUpdate(({ opacity }) => {
+          otherMaterial.opacity = opacity;
+          if (otherEdgeMaterial) {
+            otherEdgeMaterial.uniforms['lineOpacity'].value = opacity;
+          }
+        })
+        .onComplete(() => {
+          other.visible = false;
+          other.userData['fixedScale'] = false;
+          if (otherEdgeLines) {
+            otherEdgeLines.visible = false;
+          }
+        })
+        .start();
+    }
+
+    this.ngZone.run(() => this.sectionFocus.emit(config));
 
     new Tween(mesh.position, this.tweenGroup)
       .to({ x: targetPosition.x, y: targetPosition.y, z: targetPosition.z }, 850)
@@ -514,13 +607,25 @@ export class ThreeModelComponent implements OnInit, AfterViewInit, OnDestroy {
       })
       .start();
 
+    if (baseRotation) {
+      mesh.rotation.copy(baseRotation);
+      const rotationData = { angle: 0 };
+      new Tween(rotationData, this.tweenGroup)
+        .to({ angle: Math.PI * 1.5 }, 900)
+        .easing(Easing.Cubic.Out)
+        .onUpdate(({ angle }) => {
+          mesh.rotation.y = baseRotation.y + angle;
+        })
+        .start();
+    }
+
     if (edgeLines) {
       edgeLines.visible = false;
     }
 
     new Tween({ opacity: material.opacity }, this.tweenGroup)
       .to({ opacity: 0 }, 650)
-      .delay(550)
+      .delay(520)
       .easing(Easing.Cubic.In)
       .onUpdate(({ opacity }) => {
         material.opacity = opacity;
@@ -531,7 +636,7 @@ export class ThreeModelComponent implements OnInit, AfterViewInit, OnDestroy {
       .onComplete(() => {
         mesh.visible = false;
         this.selectionInProgress = false;
-        this.sectionReveal.emit(config);
+        this.ngZone.run(() => this.sectionReveal.emit(config));
       })
       .start();
   }
@@ -547,7 +652,7 @@ export class ThreeModelComponent implements OnInit, AfterViewInit, OnDestroy {
       this.canvasEl.style.cursor = 'default';
     }
 
-    if (!this.labelElement) {
+    if (!this.labelElement || !this.labelTitleEl || !this.labelBodyEl) {
       return;
     }
 
@@ -562,7 +667,8 @@ export class ThreeModelComponent implements OnInit, AfterViewInit, OnDestroy {
       return;
     }
 
-    this.labelElement.textContent = config.label;
+    this.labelTitleEl.textContent = config.label;
+    this.labelBodyEl.textContent = config.description;
     this.labelElement.style.opacity = '1';
   }
 
@@ -578,14 +684,31 @@ export class ThreeModelComponent implements OnInit, AfterViewInit, OnDestroy {
     const rect = this.canvasEl.getBoundingClientRect();
     const x = ((vector.x + 1) / 2) * rect.width;
     const y = ((-vector.y + 1) / 2) * rect.height;
+    const offset = 36;
+    const margin = 32;
 
-    this.labelElement.style.transform = `translate(-50%, -50%) translate(${x}px, ${y}px)`;
+    const clampedX = Math.min(Math.max(x, margin), rect.width - margin);
+    const clampedY = Math.min(Math.max(y - offset, margin), rect.height - margin);
+
+    this.labelElement.style.left = `${clampedX}px`;
+    this.labelElement.style.top = `${clampedY}px`;
+    this.labelElement.style.transform = 'translate(-50%, -100%)';
   }
 
   private createLabel(): void {
     this.labelElement = this.document.createElement('div');
     this.labelElement.className = 'nav-label';
     this.labelElement.style.opacity = '0';
+    this.labelElement.setAttribute('role', 'status');
+    this.labelElement.setAttribute('aria-live', 'polite');
+
+    this.labelTitleEl = this.document.createElement('span');
+    this.labelTitleEl.className = 'nav-label__title';
+    this.labelBodyEl = this.document.createElement('p');
+    this.labelBodyEl.className = 'nav-label__body';
+
+    this.labelElement.appendChild(this.labelTitleEl);
+    this.labelElement.appendChild(this.labelBodyEl);
     this.container.appendChild(this.labelElement);
   }
 
@@ -597,7 +720,12 @@ export class ThreeModelComponent implements OnInit, AfterViewInit, OnDestroy {
     }
 
     this.tweenGroup.update(performance.now());
-    this.recenterAndFrameModel();
+    if (this.recenterPending && !this.selectionInProgress && !this.hoveredMesh && !this.activeMesh) {
+      const recentered = this.recenterAndFrameModel();
+      if (recentered) {
+        this.recenterPending = false;
+      }
+    }
     this.updatePulse();
     this.updateLabelPosition();
     this.renderer.render(this.scene, this.camera);
@@ -615,9 +743,15 @@ export class ThreeModelComponent implements OnInit, AfterViewInit, OnDestroy {
         continue;
       }
 
-      const amplitude = mesh === this.hoveredMesh ? 0.06 : 0.03;
-      const pulse = 1 + amplitude * Math.sin(elapsed * 2 + mesh.id * 0.5);
-      mesh.scale.set(baseScale.x * pulse, baseScale.y * pulse, baseScale.z * pulse);
+      if (mesh === this.hoveredMesh && this.isExploded && !this.selectionInProgress) {
+        const amplitude = 0.08;
+        const pulse = 1 + amplitude * (0.5 * (Math.sin(elapsed * 3.2) + 1));
+        this.scaleVector.set(baseScale.x * pulse, baseScale.y * pulse, baseScale.z * pulse);
+        mesh.scale.lerp(this.scaleVector, 0.2);
+      } else {
+        this.scaleVector.set(baseScale.x, baseScale.y, baseScale.z);
+        mesh.scale.lerp(this.scaleVector, 0.25);
+      }
     }
   }
 }


### PR DESCRIPTION
## Summary
- widen orthographic framing margins so the cube stays comfortably inside the grid across screen sizes
- steer the focused mesh toward the camera axis while keeping neighbours faded and still
- emit focus and reveal events back inside Angular's zone so the routed content overlay appears without a refresh

## Testing
- `npm run build` *(fails: ng CLI binary unavailable in the container runtime)*

------
https://chatgpt.com/codex/tasks/task_e_68ccecf20d2c832d828fa0e03db04ea5