### PR TITLE
Ensure orthographic frustum expansion runs in production

### DIFF
--- a/src/app/three-model/three-model.component.ts
+++ b/src/app/three-model/three-model.component.ts
@@ -9,7 +9,8 @@ import {
   OnDestroy,
   OnInit,
   Output,
-  PLATFORM_ID
+  PLATFORM_ID,
+  isDevMode
 } from '@angular/core';
 import * as THREE from 'three';
 import { OBJLoader } from 'three/examples/jsm/loaders/OBJLoader.js';
@@ -20,6 +21,17 @@ export type SectionKey = 'about' | 'resume' | 'portfolio' | 'wiki';
 export interface SectionEvent {
   key: SectionKey;
   label: string;
+}
+
+interface FrustumValidationSnapshot {
+  maxNdcX: number;
+  maxNdcY: number;
+  widthScale: number;
+  heightScale: number;
+}
+
+interface FrustumAdjustmentRecord extends FrustumValidationSnapshot {
+  timestamp: number;
 }
 
 const NAV_TARGETS: Record<string, SectionEvent> = {
@@ -65,6 +77,13 @@ export class ThreeModelComponent implements OnInit, AfterViewInit, OnDestroy {
   private baseRadius = 1;
   private sceneRadius = 1;
   private tempVector = new THREE.Vector3();
+  private readonly frustumValidationEnabled = isDevMode();
+  private readonly frustumValidationEpsilon = 1e-3;
+  private readonly boundingBoxCorners: THREE.Vector3[] = Array.from({ length: 8 }, () => new THREE.Vector3());
+  private hasBoundingBoxCorners = false;
+  private frustumProbeVector = new THREE.Vector3();
+  private lastFrustumDiagnostics: FrustumValidationSnapshot | null = null;
+  private frustumAdjustmentLog: FrustumAdjustmentRecord[] = [];
 
   constructor(
     private el: ElementRef,
@@ -233,13 +252,10 @@ export class ThreeModelComponent implements OnInit, AfterViewInit, OnDestroy {
     const radius = Math.max(this.sceneRadius, this.baseRadius, 1);
     const aspect = viewWidth / viewHeight;
     const padding = 1.35;
-    const halfSize = radius * padding;
-
-    this.camera.left = -halfSize * aspect;
-    this.camera.right = halfSize * aspect;
-    this.camera.top = halfSize;
-    this.camera.bottom = -halfSize;
-    this.camera.updateProjectionMatrix();
+    const baseHalfHeight = radius * padding;
+    const baseHalfWidth = baseHalfHeight * aspect;
+    let halfWidth = Math.max(baseHalfWidth, Math.abs(this.camera.right), Math.abs(this.camera.left));
+    let halfHeight = Math.max(baseHalfHeight, Math.abs(this.camera.top), Math.abs(this.camera.bottom));
 
     const distance = radius * 2.6;
     this.tempVector
@@ -248,6 +264,103 @@ export class ThreeModelComponent implements OnInit, AfterViewInit, OnDestroy {
       .add(this.cameraTarget);
     this.camera.position.copy(this.tempVector);
     this.camera.lookAt(this.cameraTarget);
+    this.camera.updateMatrixWorld(true);
+
+    this.camera.left = -halfWidth;
+    this.camera.right = halfWidth;
+    this.camera.top = halfHeight;
+    this.camera.bottom = -halfHeight;
+    this.camera.updateProjectionMatrix();
+
+    if (this.hasBoundingBoxCorners) {
+      let maxNdcX = 0;
+      let maxNdcY = 0;
+
+      for (const corner of this.boundingBoxCorners) {
+        this.frustumProbeVector.copy(corner).project(this.camera);
+        maxNdcX = Math.max(maxNdcX, Math.abs(this.frustumProbeVector.x));
+        maxNdcY = Math.max(maxNdcY, Math.abs(this.frustumProbeVector.y));
+      }
+
+      const widthScale = maxNdcX > 1 ? maxNdcX + this.frustumValidationEpsilon : 1;
+      const heightScale = maxNdcY > 1 ? maxNdcY + this.frustumValidationEpsilon : 1;
+      const adjustmentsApplied = widthScale > 1 || heightScale > 1;
+
+      if (adjustmentsApplied) {
+        halfWidth *= widthScale;
+        halfHeight *= heightScale;
+        this.camera.left = -halfWidth;
+        this.camera.right = halfWidth;
+        this.camera.top = halfHeight;
+        this.camera.bottom = -halfHeight;
+        this.camera.updateProjectionMatrix();
+      }
+
+      if (this.frustumValidationEnabled) {
+        const snapshot: FrustumValidationSnapshot = {
+          maxNdcX,
+          maxNdcY,
+          widthScale,
+          heightScale
+        };
+        this.lastFrustumDiagnostics = snapshot;
+
+        if (adjustmentsApplied) {
+          this.recordFrustumAdjustment(snapshot);
+        }
+      }
+    } else if (this.frustumValidationEnabled) {
+      this.lastFrustumDiagnostics = null;
+    }
+  }
+
+  private cacheBoundingBoxCorners(): void {
+    if (this.boundingBox.isEmpty()) {
+      this.hasBoundingBoxCorners = false;
+      return;
+    }
+
+    const { min, max } = this.boundingBox;
+    if (
+      !Number.isFinite(min.x) ||
+      !Number.isFinite(min.y) ||
+      !Number.isFinite(min.z) ||
+      !Number.isFinite(max.x) ||
+      !Number.isFinite(max.y) ||
+      !Number.isFinite(max.z)
+    ) {
+      this.hasBoundingBoxCorners = false;
+      return;
+    }
+
+    const corners = this.boundingBoxCorners;
+    corners[0].set(min.x, min.y, min.z);
+    corners[1].set(min.x, min.y, max.z);
+    corners[2].set(min.x, max.y, min.z);
+    corners[3].set(min.x, max.y, max.z);
+    corners[4].set(max.x, min.y, min.z);
+    corners[5].set(max.x, min.y, max.z);
+    corners[6].set(max.x, max.y, min.z);
+    corners[7].set(max.x, max.y, max.z);
+    this.hasBoundingBoxCorners = true;
+  }
+
+  private recordFrustumAdjustment(snapshot: FrustumValidationSnapshot): void {
+    if (!this.frustumValidationEnabled) {
+      return;
+    }
+
+    const entry: FrustumAdjustmentRecord = {
+      ...snapshot,
+      timestamp: Date.now()
+    };
+
+    this.frustumAdjustmentLog.push(entry);
+    if (this.frustumAdjustmentLog.length > 20) {
+      this.frustumAdjustmentLog.shift();
+    }
+
+    console.debug('[ThreeModelComponent] Expanded camera frustum', entry);
   }
 
   private recenterAndFrameModel(force = false): void {
@@ -262,6 +375,7 @@ export class ThreeModelComponent implements OnInit, AfterViewInit, OnDestroy {
     this.model.updateMatrixWorld(true);
     this.boundingBox.setFromObject(this.model);
     if (this.boundingBox.isEmpty()) {
+      this.hasBoundingBoxCorners = false;
       return;
     }
 
@@ -271,6 +385,7 @@ export class ThreeModelComponent implements OnInit, AfterViewInit, OnDestroy {
       !Number.isFinite(this.boundingSphere.center.y) ||
       !Number.isFinite(this.boundingSphere.center.z)
     ) {
+      this.hasBoundingBoxCorners = false;
       return;
     }
 
@@ -281,9 +396,11 @@ export class ThreeModelComponent implements OnInit, AfterViewInit, OnDestroy {
       this.boundingBox.getBoundingSphere(this.boundingSphere);
     }
     if (!Number.isFinite(this.boundingSphere.radius) || this.boundingSphere.radius <= 0) {
+      this.hasBoundingBoxCorners = false;
       return;
     }
 
+    this.cacheBoundingBoxCorners();
     this.cameraTarget.copy(this.boundingSphere.center);
 
     const normalizedRadius = Math.max(this.boundingSphere.radius, 1);


### PR DESCRIPTION
## Summary
- ensure projecting cached bounding-box corners expands the orthographic frustum in every build while keeping diagnostics and adjustment logs behind the dev-only flag
- cache world-space box corners alongside existing bounds data and retain diagnostics/logs for any frustum enlargements while running in dev mode
- prevent stale corner data when bounds are invalid and keep previous extents so the runtime validation can highlight regressions without chattering logs

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cdee590d30832db7d03d82a5ff63a0